### PR TITLE
fix bug caused by deleting the `story` attribute

### DIFF
--- a/play.py
+++ b/play.py
@@ -156,7 +156,7 @@ def play_aidungeon_2():
 
     while True:
         if story_manager.story != None:
-            del story_manager.story
+            story_manager.story = None
 
         while story_manager.story is None: 
             print("\n\n")


### PR DESCRIPTION
```
> /restart
Please rate the story quality from 1-10: 5
Game saved.
To load the game, type 'load' and enter the following ID: 14b71db6-1f23-11ea-842b-0242ac1c0002
Traceback (most recent call last):
File "play.py", line 468, in <module>
play_aidungeon_2()
File "play.py", line 161, in play_aidungeon_2
while story_manager.story is None:
AttributeError: 'UnconstrainedStoryManager' object has no attribute 'story'
```