### PR TITLE
Repair unbalanced quotes instead of removing multi-sentence dialogue

### DIFF
--- a/generator/gpt2/gpt2_generator.py
+++ b/generator/gpt2/gpt2_generator.py
@@ -47,7 +47,6 @@ class GPT2Generator:
     def prompt_replace(self, prompt):
         # print("\n\nBEFORE PROMPT_REPLACE:")
         # print(repr(prompt))
-        prompt = prompt.replace('."', '".')
         prompt = prompt.replace("#", "")
         prompt = prompt.replace("*", "")
         prompt = prompt.replace("\n\n", "\n")

--- a/story/utils.py
+++ b/story/utils.py
@@ -84,11 +84,18 @@ def remove_profanity(text):
 
 def cut_trailing_quotes(text):
     num_quotes = text.count('"')
-    if num_quotes % 2 is 0:
+    if num_quotes % 2 == 0:
         return text
     else:
         final_ind = text.rfind('"')
         return text[:final_ind]
+
+def fix_trailing_quotes(text):
+    num_quotes = text.count('"')
+    if num_quotes % 2 == 0:
+        return text
+    else:
+        return text + '"'
 
 
 def split_first_sentence(text):
@@ -144,7 +151,7 @@ def cut_trailing_sentence(text):
 
     text = text[:last_punc+1]
 
-    text = cut_trailing_quotes(text)
+    text = fix_trailing_quotes(text)
     text = cut_trailing_action(text)
     return text
 


### PR DESCRIPTION
This preserves more dialogue in the output and avoids the dumb workaround which swaps periods with quotes so that cut_trailing_sentences() doesn't delete the neighboring quotation mark. A sentence is a good stopping point regardless of whether it is in the middle of a quoted expression, so you don't need to remove previous sentences if a sentence cuts off.
See issue #20.