### PR TITLE
Allow changing story memory

### DIFF
--- a/generator/gpt2/gpt2_generator.py
+++ b/generator/gpt2/gpt2_generator.py
@@ -13,7 +13,7 @@ tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 
 
 class GPT2Generator:
-    def __init__(self, generate_num=80, temperature=0.4, top_p=0.9, censor=False):
+    def __init__(self, generate_num=80, temperature=0.4, top_p=0.9, censor=False, max_depth=20):
         self.generate_num = generate_num
         self.default_gen_num = generate_num
         self.temp = temperature
@@ -27,6 +27,8 @@ class GPT2Generator:
 
         self.batch_size = 1
         self.samples = 1
+
+        self.max_depth = max_depth
 
         models_dir = os.path.expanduser(os.path.expandvars(self.model_dir))
         self.enc = encoder.get_encoder(self.model_name, models_dir)
@@ -122,9 +124,9 @@ class GPT2Generator:
 
         result = text
         result = self.result_replace(result, re.findall(r".+?(?:\.{1,3}|[!\?]|$)(?!\")", last_prompt))
-        if len(result) == 0 and depth < 20:
+        if len(result) == 0 and depth < self.max_depth:
             return self.generate(self.cut_down_prompt(prompt), depth=depth+1)
-        elif result.count(".") < 2 and depth < 20:
+        elif result.count(".") < 2 and depth < self.max_depth:
             return self.generate(prompt, depth=depth+1)
 
         return result

--- a/play.py
+++ b/play.py
@@ -172,6 +172,7 @@ def instructions():
     text += '\n  "/temp #.#"       Changes the AI\'s temperature'
     text += '\n                    (higher temperature = less focused). Default is 0.4.'
     text += '\n  "/top ##"         Changes the AI\'s top_p. Default is 0.9.'
+    text += '\n  "/memory ##"      Changes the number of previous steps to include in the memory for the generator. Default is 20.'
     text += '\n  "/remember XXX"   Commit something important to the AI\'s memory for that session.'
     text += '\n  "/context"        Rewrites everything your AI has currently committed to memory.'
     text += '\n  "/editcontext     Lets you rewrite specific parts of the context.'
@@ -188,6 +189,7 @@ def play_aidungeon_2():
 
     upload_story = True
     ping = False
+    memory = 20
 
     print("\nInitializing AI Dungeon! (This might take a few minutes)\n")
     generator = GPT2Generator()
@@ -213,10 +215,11 @@ def play_aidungeon_2():
                     context, prompt = character, setting_description
                 else:
                     context, prompt = get_curated_exposition(setting_key, character_key, name, character, setting_description)
-                change_config = input("Would you like to enter a new temp and top_p now? (default: 0.4, 0.9) (y/N) ")
+                change_config = input("Would you like to enter new parameters now? (default: temp=0.4, top_p=0.9, memory=20) (y/N) ")
                 if change_config.lower() == "y":
                     story_manager.generator.change_temp(float(input("Enter a new temp (default 0.4): ") or 0.4))
                     story_manager.generator.change_top_p(float(input("Enter a new top_p (default 0.9): ") or 0.9))
+                    memory = int(input("Enter new memory value (default 20): ") or memory)
                     console_print("Please wait while the AI model is regenerated...")
                     story_manager.generator.gen_output()
                 console_print(instructions())
@@ -225,6 +228,7 @@ def play_aidungeon_2():
                 story_manager.start_new_story(
                     prompt, context=context, upload_story=upload_story
                 )
+                story_manager.set_memory(memory)
                 print("\n")
                 console_print(str(story_manager.story))
                 story_manager.generator.generate_num = story_manager.generator.default_gen_num
@@ -422,6 +426,17 @@ def play_aidungeon_2():
                             console_print("Set top_p to {}".format(story_manager.generator.top_p))
                         except:
                             console_print("Failed to set top_p. Example usage: top 0.9")
+                            continue
+
+                elif command == "memory":
+                    if len(args) == 0:
+                        console_print("Current memory: %d" % story_manager.story.memory)
+                    else:
+                        try:
+                            story_manager.set_memory(int(args[0]))
+                            console_print("Set memory to %d" % story_manager.story.memory)
+                        except:
+                            console_print("Failed to set memory. Example usage: /memory 20")
                             continue
                 
                 elif command == 'remember':


### PR DESCRIPTION
Add the length of memory (how many actions the generator looks back at) as a parameter that can be changed at the start of a new game, at runtime with /memory, and is saved and loaded with each story.