### PR TITLE
Text edit function, /alter2 command using said function

### DIFF
--- a/play.py
+++ b/play.py
@@ -466,51 +466,31 @@ def play_aidungeon_2():
                 elif command == 'editcontext':
                     try:
                         current_context = story_manager.get_context()
-                        current_context = current_context.strip()
-                        context_list = current_context.split(".")
-
-                        if context_list[-1] == "":
-                            del context_list[-1]
-
-                        for i in range(len(context_list)):
-                            context_list[i] = context_list[i].strip()
-
-                        console_print("Current story context:\n" + current_context + "\n")
-                        console_print("0) Remove a sentence\n1) Edit a sentence\n2) Add a new sentence\n3) Cancel\n")
-                        choice = get_num_options(4)
-
-                        if choice == 0:
-                            console_print("Pick a sentence to remove:\n")
-                            for i in range(len(context_list)):
-                                console_print(str(i) + ") " + context_list[i])
-                            choice = get_num_options(len(context_list))
-                            del context_list[choice]
-                        elif choice == 1:
-                            console_print("Pick a sentence to edit:\n")
-                            for i in range(len(context_list)):
-                                console_print(str(i) + ") " + context_list[i])
-                            choice = get_num_options(len(context_list))
-                            console_print(context_list[choice])
-                            context_list[choice] = input("\nWrite the new sentence:\n")
-                        elif choice == 2:
-                            context_list.append(input("Write a new sentence:\n"))
+                        new_context = string_edit(current_context)
+                        if new_context is None:
+                            pass
                         else:
-                            console_print("Cancelled.\n")
-                            continue
+                            story_manager.set_context(new_context)
+                            console_print("Story context updated.\n")
+                    except:
+                        console_print("Something went wrong, cancelling.")
+                        pass
 
-                        current_context = ""
-                        for i in range(len(context_list)):
-                            if context_list[i] == "":
-                                continue
-                            if context_list[i][-1] == ".":
-                                context_list[i] = context_list[i] + " "
-                            elif context_list[i][-1] != " ":
-                                context_list[i] = context_list[i] + ". "
-                            current_context = current_context + context_list[i]
-                        current_context = current_context.strip()
-                        story_manager.set_context(current_context)
-                        console_print("Story context updated.\n")
-
+                elif command == 'alter2':
+                    try:
+                        try:
+                            current_result = story_manager.story.results[-1]
+                        except IndexError:
+                            current_result = story_manager.story.story_start
+                        new_result = string_edit(current_result)
+                        if new_result is None:
+                            pass
+                        else:
+                            try:
+                                story_manager.story.results[-1] = new_result
+                            except IndexError:
+                                story_manager.story.story_start = new_result
+                            console_print("Result updated.\n")
                     except:
                         console_print("Something went wrong, cancelling.")
                         pass

--- a/play.py
+++ b/play.py
@@ -173,8 +173,7 @@ def instructions():
     text += '\n                    (higher temperature = less focused). Default is 0.4.'
     text += '\n  "/top ##"         Changes the AI\'s top_p. Default is 0.9.'
     text += '\n  "/remember XXX"   Commit something important to the AI\'s memory for that session.'
-    text += '\n  "/context"        Rewrites everything your AI has currently committed to memory.'
-    text += '\n  "/editcontext     Lets you rewrite specific parts of the context.'
+    text += '\n  "/context"        Edit what your AI has currently committed to memory.'
     return text
 
 
@@ -373,17 +372,6 @@ def play_aidungeon_2():
                         console_print(story_manager.story.story_start)
                     continue
 
-                elif command == "alter": 
-                    if len(story_manager.story.results) is 0: 
-                        console_print("There's no results to alter.\n") 
-                        continue 
-     
-                    console_print("\nThe AI thinks this was what happened:\n") 
-                    print(story_manager.story.results[-1]) 
-                    result = input("\nWhat actually happened was (use \\n for new line):\n\n") 
-                    result = result.replace("\\n", "\n") 
-                    story_manager.story.results[-1] = result 
-
                 elif command == "infto":
 
                     if len(args) != 1:
@@ -457,15 +445,10 @@ def play_aidungeon_2():
 
                     continue
 
-                elif command == "context":
-                    console_print("Current story context: \n" + story_manager.get_context() + "\n")
-                    new_context = input("Enter a new context describing the general status of your character and story: ")
-                    story_manager.set_context(new_context)
-                    console_print("Story context updated.\n")
-
-                elif command == 'editcontext':
+                elif command == 'context':
                     try:
                         current_context = story_manager.get_context()
+                        console_print("Current story context: \n")
                         new_context = string_edit(current_context)
                         if new_context is None:
                             pass
@@ -476,8 +459,9 @@ def play_aidungeon_2():
                         console_print("Something went wrong, cancelling.")
                         pass
 
-                elif command == 'alter2':
+                elif command == 'alter':
                     try:
+                        console_print("\nThe AI thinks this was what happened:\n")
                         try:
                             current_result = story_manager.story.results[-1]
                         except IndexError:

--- a/story/utils.py
+++ b/story/utils.py
@@ -358,21 +358,35 @@ def string_edit(text):
         console_print("Pick a sentence to edit:\n")
         for i in range(len(sentence_choices)):
             console_print(str(i) + ") " + sentence_choices[i])
-        choice = get_num_options(len(sentence_choices))
-        console_print("\n" + sentence_choices[choice])
-        new_sentence = input("\nWrite the new sentence:\n")
-        new_sentence = new_sentence.strip()
-        new_sentence = new_sentence.replace("  ", " ")
-        if new_sentence != "":
-            if new_sentence[-1] not in [".", "!", "?", ",", "\"", "\'"]:
-                new_sentence += "."
-            sentence_choices[choice] = new_sentence
+        console_print(str(len(sentence_choices)) + ") Cancel")
+        choice = get_num_options(len(sentence_choices) + 1)
+        while choice != len(sentence_choices):
+            console_print("\n" + sentence_choices[choice])
+            new_sentence = input("\nWrite the new sentence:\n")
+            new_sentence = new_sentence.strip()
+            new_sentence = new_sentence.replace("  ", " ")
+            if new_sentence != "":
+                if new_sentence[-1] not in [".", "!", "?", ",", "\"", "\'"]:
+                    new_sentence += "."
+                sentence_choices[choice] = new_sentence
+            for i in range(len(sentence_choices)):
+                console_print(str(i) + ") " + sentence_choices[i])
+            console_print(str(len(sentence_choices)) + ") Cancel")
+            choice = get_num_options(len(sentence_choices) + 1)
     elif choice == 1:
         console_print("Pick a sentence to remove:\n")
         for i in range(len(sentence_choices)):
             console_print(str(i) + ") " + sentence_choices[i])
-        choice = get_num_options(len(sentence_choices))
-        sentence_choices[choice] = ""
+        console_print(str(len(sentence_choices)) + ") Cancel")
+        choice = get_num_options(len(sentence_choices) + 1)
+        while choice != len(sentence_choices):
+            sentence_choices[choice] = ""
+            console_print("\n")
+            for i in range(len(sentence_choices)):
+                if sentence_choices[i] != "":
+                    console_print(str(i) + ") " + sentence_choices[i])
+            console_print(str(len(sentence_choices)) + ") Cancel")
+            choice = get_num_options(len(sentence_choices) + 1)
     elif choice == 2:
         new_sentence = input("Write a new sentence:\n")
         new_sentence = new_sentence.strip()

--- a/story/utils.py
+++ b/story/utils.py
@@ -324,6 +324,19 @@ def string_to_sentence_list(text):
 def string_edit(text):
     text = text.strip()
     sentences = string_to_sentence_list(text)
+    new_sentences = []
+    for i in range(len(sentences) - 1):
+        if len(sentences[i]) + len(sentences[i+1]) < 40 and sentences[i] != "<break>" and sentences[i+1] != "<break>":
+            merged_sentence = sentences[i] + " " + sentences[i+1]
+            print(merged_sentence)
+            new_sentences.append(merged_sentence)
+            sentences[i+1] = ""
+        else:
+            if sentences[i] != "":
+                new_sentences.append(sentences[i])
+    if sentences[-1] != "":
+        new_sentences.append(sentences[-1])
+    sentences = new_sentences
     sentence_choices = []
     for i in sentences:
         if i != "<break>":

--- a/story/utils.py
+++ b/story/utils.py
@@ -329,17 +329,17 @@ def string_edit(text):
         if i != "<break>":
             sentence_choices.append(i)
 
+    console_print(text)
     if len(sentence_choices) == 0:
-        console_print("Nothing to edit. Would you like to add a sentence?\n0) Add a new sentence\n1) Cancel\n")
+        console_print("No text to edit. Would you like to write something?\n0) Write new text\n1) Cancel\n")
         choice = get_num_options(2)
         if choice == 0:
-            choice = 2
-        else:
             choice = 3
+        else:
+            choice = 4
     else:
-        console_print(text)
-        console_print("\n0) Edit a sentence\n1) Remove a sentence\n2) Add a new sentence\n3) Cancel\n")
-        choice = get_num_options(4)
+        console_print("\n0) Edit a sentence\n1) Remove a sentence\n2) Add a new sentence\n3) Rewrite all\n4) Cancel\n")
+        choice = get_num_options(5)
 
     if choice == 0:
         console_print("Pick a sentence to edit:\n")
@@ -349,6 +349,7 @@ def string_edit(text):
         console_print("\n" + sentence_choices[choice])
         new_sentence = input("\nWrite the new sentence:\n")
         new_sentence = new_sentence.strip()
+        new_sentence = new_sentence.replace("  ", " ")
         if new_sentence != "":
             if new_sentence[-1] not in [".", "!", "?", ",", "\"", "\'"]:
                 new_sentence += "."
@@ -362,11 +363,17 @@ def string_edit(text):
     elif choice == 2:
         new_sentence = input("Write a new sentence:\n")
         new_sentence = new_sentence.strip()
+        new_sentence = new_sentence.replace("  ", " ")
         if new_sentence != "":
             if new_sentence[-1] not in [".", "!", "?", ",", "\"", "\'"]:
                 new_sentence += "."
             sentences.append("")
             sentence_choices.append(new_sentence)
+    elif choice == 3:
+        new_text = (input("Enter the new text (use \\n for new line):\n"))
+        new_text = new_text.replace("  ", " ")
+        new_text = new_text.replace("\\n", "\n")
+        return new_text
     else:
         console_print("Cancelled.\n")
         return

--- a/story/utils.py
+++ b/story/utils.py
@@ -300,3 +300,81 @@ def second_to_first_person(text):
             text = replace_outside_quotes(text, variation[0], variation[1])
 
     return capitalize_first_letters(text[1:])
+
+
+def string_to_sentence_list(text):
+    text = "    " + text + "     "
+    text = text.replace("\n", "<stop><break><stop>")
+    text = re.sub("(Mr|St|Mrs|Ms|Dr|Prof|Capt|Cpt|Lt|Mt)(\.)", "\\1<prd>", text)
+    text = re.sub("(Inc|Ltd|Jr|Sr|Co)(\.)([\s\"\',])*(?=[a-z])", "\\1<prd>\\2", text)
+    text = re.sub("(\s)([A-Za-z])(\.)", "\\1\\2<prd>", text)
+    text = re.sub("([A-Za-z0-9])(\.)(?![\s\"\'\.])", "\\1<prd>", text)
+    text = re.sub("<prd>([A-Za-z])(\.)([\s\"\',])*(?=[a-z])", "<prd>\\1<prd>\\3", text)
+    text = re.sub("([\.!\?])([\"\'])([\.,])?", "\\1\\2\\3<stop>", text)
+    text = re.sub("([\.!\?])([^\"\'\.!\?])", "\\1<stop>\\2", text)
+    text = text.replace("<prd>",".")
+    text = re.sub("(<stop>)(\s)*(<stop>)*(\s)*(<stop>)*","<stop>",text)
+    sentences = text.split("<stop>")
+    if sentences[-1] == "":
+        del sentences[-1]
+    sentences = [s.strip() for s in sentences]
+    return sentences
+
+
+def string_edit(text):
+    text = text.strip()
+    sentences = string_to_sentence_list(text)
+    sentence_choices = []
+    for i in sentences:
+        if i != "<break>":
+            sentence_choices.append(i)
+
+    if len(sentence_choices) == 0:
+        console_print("Nothing to edit. Would you like to add a sentence?\n0) Add a new sentence\n1) Cancel\n")
+        choice = get_num_options(2)
+        if choice == 0:
+            choice = 2
+        else:
+            choice = 3
+    else:
+        console_print(text)
+        console_print("\n0) Edit a sentence\n1) Remove a sentence\n2) Add a new sentence\n3) Cancel\n")
+        choice = get_num_options(4)
+
+    if choice == 0:
+        console_print("Pick a sentence to edit:\n")
+        for i in range(len(sentence_choices)):
+            console_print(str(i) + ") " + sentence_choices[i])
+        choice = get_num_options(len(sentence_choices))
+        console_print("\n" + sentence_choices[choice])
+        new_sentence = input("\nWrite the new sentence:\n")
+        new_sentence = new_sentence.strip()
+        if new_sentence != "":
+            if new_sentence[-1] not in [".", "!", "?", ",", "\"", "\'"]:
+                new_sentence += "."
+            sentence_choices[choice] = new_sentence
+    elif choice == 1:
+        console_print("Pick a sentence to remove:\n")
+        for i in range(len(sentence_choices)):
+            console_print(str(i) + ") " + sentence_choices[i])
+        choice = get_num_options(len(sentence_choices))
+        sentence_choices[choice] = ""
+    elif choice == 2:
+        new_sentence = input("Write a new sentence:\n")
+        new_sentence = new_sentence.strip()
+        if new_sentence != "":
+            if new_sentence[-1] not in [".", "!", "?", ",", "\"", "\'"]:
+                new_sentence += "."
+            sentences.append("")
+            sentence_choices.append(new_sentence)
+    else:
+        console_print("Cancelled.\n")
+        return
+    new_text = ""
+    for i in range(len(sentences)):
+        if sentences[i] == "<break>":
+            new_text = new_text + "\n"
+        else:
+            new_text = new_text + sentence_choices[i - (sentences[0:i].count("<break>"))] + " "
+    new_text = new_text.strip()
+    return new_text


### PR DESCRIPTION
Couldn't think of a better name for the command. Could maybe have stolen /alter command and merged the original command into this, as an "rewrite all" option, but not sure how much people would like needing an extra step if they use it a lot.

I've probably spent more effort on this than I should, but it feels really good to use when I'm testing it out. Makes it so easy to tweak the AI's responses, like removing a sentence that ruins an otherwise good response, or editing some part where the AI gets confused about who is doing what. And you don't lose your linebreaks! Only part I'm slightly dissatisfied is how many sentences you end up with when the dialogue starts spamming you with very short dialogue, like here:

> A voice calls back. "I am a tree".
> "Are you a tree?" You ask.
> "Yes I am. Are you?"
> "No, I'm not a tree".

> 0) A voice calls back.
> 1) "I am a tree".
> 2) "Are you a tree?"
> 3) You ask.
> 4) "Yes I am.
> 5) Are you?"
> 6) "No, I'm not a tree".

But it probably can't be helped.

Oh, and it also lets you edit `story_start` when there's no result to edit, not sure why the original /alter command didn't do that.