### PR TITLE
save and load generator parameters along with story

### DIFF
--- a/generator/gpt2/gpt2_generator.py
+++ b/generator/gpt2/gpt2_generator.py
@@ -151,7 +151,11 @@ class GPT2Generator:
         )
         
     def change_temp(self, t):
+        changed = t != self.temp
         self.temp = t
+        return changed
         
     def change_top_p(self, t):
+        changed = t != self.top_p
         self.top_p = t
+        return changed

--- a/play.py
+++ b/play.py
@@ -186,7 +186,7 @@ def play_aidungeon_2():
 
     print("\nInitializing AI Dungeon! (This might take a few minutes)\n")
     generator = GPT2Generator()
-    story_manager = UnconstrainedStoryManager(generator)
+    story_manager = UnconstrainedStoryManager(generator, upload_story=upload_story, cloud=False)
     print("\n")
 
     with open("opening.txt", "r", encoding="utf-8") as file:
@@ -227,10 +227,10 @@ def play_aidungeon_2():
             else:
                 load_ID = input("What is the ID of the saved game? (prefix with gs:// if it is a cloud save) ")
                 if load_ID.startswith("gs://"):
-                    result = story_manager.load_new_story(load_ID[5:], upload_story=upload_story, cloud=True)
-                    story_manager.story.cloud = True
+                    story_manager.cloud = True
+                    result = story_manager.load_from_storage(load_ID[5:])
                 else:
-                    result = story_manager.load_new_story(load_ID, upload_story=upload_story)
+                    result = story_manager.load_from_storage(load_ID)
                 print("\nLoading Game...\n")
                 print(result)
 
@@ -267,11 +267,11 @@ def play_aidungeon_2():
 
                 elif command == "nosaving":
                     upload_story = False
-                    story_manager.story.upload_story = False
+                    story_manager.upload_story = False
                     console_print("Saving turned off.")
 
                 elif command == "cloud":
-                    story_manager.story.cloud = True
+                    story_manager.cloud = True
                     console_print("Cloud saving turned on.")
 
                 elif command == "help":
@@ -331,16 +331,16 @@ def play_aidungeon_2():
                     else:
                         load_ID = args[0]
                     if load_ID.startswith("gs://"):
-                        story_manager.story.cloud = True
-                        result = story_manager.story.load_from_storage(load_ID[5:])
+                        story_manager.cloud = True
+                        result = story_manager.load_from_storage(load_ID[5:])
                     else:
-                        result = story_manager.story.load_from_storage(load_ID)
+                        result = story_manager.load_from_storage(load_ID)
                     console_print("\nLoading Game...\n")
                     console_print(result)
 
                 elif command == "save":
                     if upload_story:
-                        save_id = story_manager.story.save_to_storage()
+                        save_id = story_manager.save_story()
                         console_print("Game saved.")
                         console_print(f"To load the game, type 'load' and enter the following ID: {save_id}")
                     else:

--- a/story/story_manager.py
+++ b/story/story_manager.py
@@ -5,16 +5,18 @@ import uuid
 from subprocess import Popen
 
 from story.utils import *
+import atexit
+
+save_path = "./saves/"
 
 
 class Story:
     def __init__(
-        self, story_start, context="", seed=None, game_state=None, upload_story=False, cloud=False
+        self, story_start, context="", seed=None, game_state=None
     ):
         self.story_start = story_start
         self.context = context
         self.rating = -1
-        self.upload_story = upload_story
 
         # list of actions. First action is the prompt length should always equal that of story blocks
         self.actions = []
@@ -32,15 +34,6 @@ class Story:
             game_state = dict()
         self.game_state = game_state
         self.memory = 20
-        self.cloud = cloud
-
-    def __del__(self):
-        if self.upload_story:
-            self.save_to_storage()
-            console_print("Game saved.")
-            console_print(
-                "To load the game, type 'load' and enter the following ID: " + self.uuid
-            )
 
     def init_from_dict(self, story_dict):
         self.story_start = story_dict["story_start"]
@@ -88,7 +81,7 @@ class Story:
 
         return "".join(story_list)
 
-    def to_json(self):
+    def to_dict(self):
         story_dict = {}
         story_dict["story_start"] = self.story_start
         story_dict["seed"] = self.seed
@@ -100,37 +93,45 @@ class Story:
         story_dict["context"] = self.context
         story_dict["uuid"] = self.uuid
         story_dict["rating"] = self.rating
+        return story_dict
 
-        return json.dumps(story_dict)
+    def to_json(self):
+        return json.dumps(self.to_dict())
 
-    def save_to_storage(self):
-        self.uuid = str(uuid.uuid1())
 
-        save_path = "./saves/"
+class StoryManager:
+    def __init__(self, generator, upload_story=True, cloud=False):
+        self.generator = generator
+        self.story = None
+        self.inference_timeout = 120
+        self.cloud = cloud
+        self.upload_story = upload_story
+        atexit.register(self.on_exit)
 
-        if not os.path.exists(save_path):
-            os.makedirs(save_path)
+    def start_new_story(
+        self, story_prompt, context="", game_state=None, upload_story=False
+    ):
+        self.upload_story = upload_story
+        block = self.generator.generate(context + story_prompt)
+        block = cut_trailing_sentence(block)
+        self.story = Story(
+            context + story_prompt + block,
+            context=context,
+            game_state=game_state
+        )
+        return str(self.story)
 
-        story_json = self.to_json()
-        file_name = "story" + str(self.uuid) + ".json"
-        f = open(os.path.join(save_path, file_name), "w")
-        f.write(story_json)
-        f.close()
-
-        FNULL = open(os.devnull, "w")
-        if self.cloud:
-            p = Popen(
-                ["gsutil", "cp", os.path.join(save_path, file_name), "gs://aidungeonstories"],
-                stdout=FNULL,
-                stderr=subprocess.STDOUT,
-            )
-        return self.uuid
+    def load_story(self, story, from_json=False):
+        if from_json:
+            self.story = Story("")
+            self.story.initialize_from_json(story)
+        else:
+            self.story = story
+        return str(story)
 
     def load_from_storage(self, story_id):
-        save_path = "./saves/"
-
         if not os.path.exists(save_path):
-            return "Error save not found."
+            return "Error: save not found."
 
         file_name = "story" + story_id + ".json"
         if self.cloud:
@@ -141,55 +142,52 @@ class Story:
         if exists:
             with open(os.path.join(save_path, file_name), "r") as fp:
                 game = json.load(fp)
-            self.init_from_dict(game)
-            return str(self)
-        else:
-            return "Error save not found."
-
-
-class StoryManager:
-    def __init__(self, generator):
-        self.generator = generator
-        self.story = None
-        self.inference_timeout = 120
-
-    def start_new_story(
-        self, story_prompt, context="", game_state=None, upload_story=False
-    ):
-        block = self.generator.generate(context + story_prompt)
-        block = cut_trailing_sentence(block)
-        self.story = Story(
-            context + story_prompt + block,
-            context=context,
-            game_state=game_state,
-            upload_story=upload_story,
-        )
-        return str(self.story)
-
-    def load_new_story(self, story_id, upload_story=False, cloud=False):
-        file_name = os.path.join("saves","story" + story_id + ".json")
-        if cloud:
-            file_name = "story" + story_id + ".json"
-            cmd = "gsutil cp gs://aidungeonstories/" + file_name + " ."
-            os.system(cmd)
-        exists = os.path.isfile(file_name)
-
-        if not exists:
-            return "Error save not found."
-
-        with open(file_name, "r") as fp:
-            game = json.load(fp)
-        self.story = Story("", upload_story=upload_story)
-        self.story.init_from_dict(game)
-        return str(self.story)
-
-    def load_story(self, story, from_json=False):
-        if from_json:
             self.story = Story("")
-            self.story.initialize_from_json(story)
+            self.story.init_from_dict(game)
+            changed = False
+            if "top_p" in game.keys():
+                changed = changed or self.generator.change_top_p(game["top_p"])
+            if "temp" in game.keys():
+                changed = changed or self.generator.change_temp(game["temp"])
+            if changed:
+                console_print("Please wait while the AI model is regenerated...")
+                self.generator.gen_output()
+            return str(self.story)
         else:
-            self.story = story
-        return str(story)
+            return "Error: save not found."
+
+    def save_story(self):
+        story_id = str(uuid.uuid1())
+        self.story.uuid = story_id
+        story_dict = self.story.to_dict()
+        story_dict["top_p"] = self.generator.top_p
+        story_dict["temp"] = self.generator.temp
+
+        if not os.path.exists(save_path):
+            os.makedirs(save_path)
+
+        story_json = json.dumps(story_dict)
+        file_name = "story" + str(story_id) + ".json"
+        sf = open(os.path.join(save_path, file_name), "w")
+        sf.write(story_json)
+        sf.close()
+
+        FNULL = open(os.devnull, "w")
+        if self.cloud:
+            p = Popen(
+                ["gsutil", "cp", os.path.join(save_path, file_name), "gs://aidungeonstories"],
+                stdout=FNULL,
+                stderr=subprocess.STDOUT,
+            )
+        return story_id
+
+    def on_exit(self):
+        if self.upload_story:
+            story_id = self.save_story()
+            console_print("Game saved.")
+            console_print(
+                "To load the game, type 'load' and enter the following ID: " + story_id
+            )
 
     def json_story(self):
         return self.story.to_json()


### PR DESCRIPTION
This shifts saving functionality to story_manager() so that generator parameters can be saved and loaded along with the story. If there is a change, then the model is regenerated. Maintains compatibility with older saves without the paramters.
Currently the game does not prompt you to change parameters at the start if you choose to load a game, which implies that the saves should include that state.