### PR TITLE
Added raw mode for models not trained on CYOA

### DIFF
--- a/generator/gpt2/gpt2_generator.py
+++ b/generator/gpt2/gpt2_generator.py
@@ -13,14 +13,14 @@ tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 
 
 class GPT2Generator:
-    def __init__(self, generate_num=80, temperature=0.4, top_p=0.9, censor=False):
+    def __init__(self, generate_num=80, temperature=0.4, top_p=0.9, censor=False, raw=False):
         self.generate_num = generate_num
         self.default_gen_num = generate_num
         self.temp = temperature
         #self.top_k = top_k
         self.top_p = top_p
         self.censor = censor
-
+        self.raw = raw
         self.model_name = "model_v5"
         self.model_dir = "generator/gpt2/models"
         self.checkpoint_path = os.path.join(self.model_dir, self.model_name)
@@ -68,7 +68,7 @@ class GPT2Generator:
         result = result.replace("\n\n", "\n")
         result = re.sub("(?<=\w)\.\.(?:\s|$)", ".", result)
         # result = first_to_second_person(result)
-        result = cut_trailing_sentence(result)
+        result = cut_trailing_sentence(result, self.raw)
         for sentence in actions:
             result = result.replace(sentence.strip()+" ", "")
         if len(result) == 0:
@@ -158,3 +158,6 @@ class GPT2Generator:
         changed = t != self.top_p
         self.top_p = t
         return changed
+
+    def change_raw(self, raw):
+        self.raw = raw

--- a/play.py
+++ b/play.py
@@ -250,7 +250,10 @@ def play_aidungeon_2():
                     if generator_config.lower() == "y":
                         try:
                             model_name = input("Model name: ")
-                            use_raw = input("Use raw narrative text as input for this model? (y/N) ")
+                            console_print("Use raw narrative text as input for this model instead of CYOA prompts?")
+                            console_print("Example user input in raw mode: He took the beast by the horns and ripped out its eyes.")
+                            console_print("Example user input in regular mode: > Take beast by horns and rip out its eyes.")
+                            use_raw = input("y/N ")
                             print("\nInitializing AI Dungeon! (This might take a few minutes)\n")
                             generator = GPT2Generator(model_name=model_name, raw=use_raw.lower()=="y")
                         except:

--- a/play.py
+++ b/play.py
@@ -246,11 +246,13 @@ def play_aidungeon_2():
                 else:
                     context, prompt = get_curated_exposition(setting_key, character_key, name, character, setting_description)
                 if generator is None:
-                    generator_config = input("Would you like to select a different generator? (default: model_v5) (y/N)")
+                    generator_config = input("Would you like to select a different generator? (default: model_v5) (y/N) ")
                     if generator_config.lower() == "y":
                         try:
+                            model_name = input("Model name: ")
+                            use_raw = input("Use raw narrative text as input for this model? (y/N) ")
                             print("\nInitializing AI Dungeon! (This might take a few minutes)\n")
-                            generator = GPT2Generator(model_name=input("Model name: "))
+                            generator = GPT2Generator(model_name=model_name, raw=use_raw.lower()=="y")
                         except:
                             console_print("Failed to set model. Make sure it is installed in generator/gpt2/models/")
                             continue

--- a/play.py
+++ b/play.py
@@ -514,7 +514,7 @@ def play_aidungeon_2():
 
                 elif command == "raw":
                     if len(args) == 0:
-                        console_print("Raw input is " + ("enabled." if raw else "disabled."))
+                        console_print("Raw input is " + ("enabled." if story_manager.generator.raw else "disabled."))
                     elif args[0] == "off":
                         if not story_manager.generator.raw:
                             console_print("Raw input is already disabled.")

--- a/play.py
+++ b/play.py
@@ -623,8 +623,8 @@ def play_aidungeon_2():
 
                     if "say" in action or "ask" in action or "\"" in action:
                         story_manager.generator.generate_num = 120
-                    else:
-                        action = action.replace("\\n", "\n")
+                else:
+                    action = action.replace("\\n", "\n")
                     
                 try:
                     result = "\n" + story_manager.act_with_timeout(action)

--- a/play.py
+++ b/play.py
@@ -178,7 +178,7 @@ def instructions():
     text += '\n or just "(thing you want to say)"'
     text += '\n'
     text += '\n If you want something to happen or be done by someone else, enter '
-    text += '\n \'!(thing you want to happen)'
+    text += '\n \'!(thing you want to happen.\\n other thing on a new line.)'
     text += '\n ex. "!A dragon swoops down and eats Sir Theo."'
     text += '\n'
     text += "\nThe following commands can be entered for any action: "
@@ -204,7 +204,7 @@ def instructions():
     text += '\n  "/temp #.#"       Changes the AI\'s temperature'
     text += '\n                    (higher temperature = less focused). Default is 0.4.'
     text += '\n  "/top ##"         Changes the AI\'s top_p. Default is 0.9.'
-    text += '\n  "/raw off/on"     Changes whether to feed the AI raw text instead of CYOA (default off)'
+    text += '\n  "/raw off/on"     Changes whether to feed the AI raw text instead of CYOA, interprets \\n as newline. (default off).'
     text += '\n  "/remember XXX"   Commit something important to the AI\'s memory for that session.'
     text += '\n  "/context"        Edit what your AI has currently committed to memory.'
     return text
@@ -251,7 +251,7 @@ def play_aidungeon_2():
                         try:
                             model_name = input("Model name: ")
                             console_print("Use raw narrative text as input for this model instead of CYOA prompts?")
-                            console_print("Example user input in raw mode: He took the beast by the horns and ripped out its eyes.")
+                            console_print("Example user input in raw mode: He took the beast by the horns and ripped out its eyes.\\n In the distance, a horn sounded.")
                             console_print("Example user input in regular mode: > Take beast by horns and rip out its eyes.")
                             use_raw = input("y/N ")
                             print("\nInitializing AI Dungeon! (This might take a few minutes)\n")
@@ -623,6 +623,8 @@ def play_aidungeon_2():
 
                     if "say" in action or "ask" in action or "\"" in action:
                         story_manager.generator.generate_num = 120
+                    else:
+                        action = action.replace("\\n", "\n")
                     
                 try:
                     result = "\n" + story_manager.act_with_timeout(action)

--- a/story/story_manager.py
+++ b/story/story_manager.py
@@ -268,7 +268,13 @@ class StoryManager:
 class UnconstrainedStoryManager(StoryManager):
     def act(self, action_choice):
         if self.generator.raw:
-            action_choice = " " + action_choice + " "
+            if len(action_choice) > 0:
+                if not action_choice[-1].isspace():
+                    action_choice = action_choice + " "
+                if not action_choice[0].isspace():
+                    action_choice = " " + action_choice
+            else:
+                action_choice = " "
         result = self.generate_result(action_choice)
         self.story.add_to_story(action_choice, result)
         return result

--- a/story/story_manager.py
+++ b/story/story_manager.py
@@ -267,6 +267,8 @@ class StoryManager:
 
 class UnconstrainedStoryManager(StoryManager):
     def act(self, action_choice):
+        if self.generator.raw:
+            action_choice = " " + action_choice + " "
         result = self.generate_result(action_choice)
         self.story.add_to_story(action_choice, result)
         return result

--- a/story/story_manager.py
+++ b/story/story_manager.py
@@ -183,6 +183,8 @@ class StoryManager:
                 changed = changed or self.generator.change_top_p(game["top_p"])
             if "temp" in game.keys():
                 changed = changed or self.generator.change_temp(game["temp"])
+            if "raw" in game.keys():
+                self.generator.change_raw(game["raw"])
             if changed:
                 console_print("Please wait while the AI model is regenerated...")
                 self.generator.gen_output()
@@ -196,6 +198,7 @@ class StoryManager:
         story_dict = self.story.to_dict()
         story_dict["top_p"] = self.generator.top_p
         story_dict["temp"] = self.generator.temp
+        story_dict["raw"] = self.generator.raw
 
         if not os.path.exists(save_path):
             os.makedirs(save_path)

--- a/story/utils.py
+++ b/story/utils.py
@@ -131,7 +131,7 @@ def cut_trailing_action(text):
     return text
 
 
-def cut_trailing_sentence(text):
+def cut_trailing_sentence(text, raw=False):
     text = standardize_punctuation(text)
     last_punc = max(text.rfind("."), text.rfind("!"), text.rfind("?"))
     if last_punc <= 0:
@@ -143,16 +143,18 @@ def cut_trailing_sentence(text):
     elif et_token == 0:
         last_punc = min(last_punc, et_token)
 
-    act_token = text.find(">")
-    if act_token > 0:
-        last_punc = min(last_punc, act_token - 1)
-    elif act_token == 0:
-        last_punc = min(last_punc, act_token)
+    if not raw:
+        act_token = text.find(">")
+        if act_token > 0:
+            last_punc = min(last_punc, act_token - 1)
+        elif act_token == 0:
+            last_punc = min(last_punc, act_token)
 
     text = text[:last_punc+1]
 
     text = fix_trailing_quotes(text)
-    text = cut_trailing_action(text)
+    if not raw:
+        text = cut_trailing_action(text)
     return text
 
 


### PR DESCRIPTION
`/raw on` turns on raw mode, which just disables most input substitutions and any string processing that assumes the role of the ">" character, or specific dialogue actions like "you say". In other words, just let the user write the next part of a narrative story, which could be written from any point of view and tense, putting the burden on the user to write coherently. This is to prepare for models that are being trained on more general data,  not necessarily CYOA.