### PR TITLE
Import readline, so arrow keys etc. will correctly behave in Linux

### DIFF
--- a/play.py
+++ b/play.py
@@ -14,6 +14,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 import base64
 import getpass
+import readline
 
 from banners.bannerRan import *
 

--- a/play.py
+++ b/play.py
@@ -14,7 +14,10 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 import base64
 import getpass
-import readline
+try:
+	import readline
+except ModuleNotFoundError:
+	pass
 
 from banners.bannerRan import *
 

--- a/story/utils.py
+++ b/story/utils.py
@@ -2,7 +2,10 @@
 import re
 from difflib import SequenceMatcher
 
-import readline
+try:
+	import readline
+except ModuleNotFoundError:
+	pass
 import yaml
 from profanityfilter import ProfanityFilter
 from func_timeout import func_timeout, FunctionTimedOut

--- a/story/utils.py
+++ b/story/utils.py
@@ -2,6 +2,7 @@
 import re
 from difflib import SequenceMatcher
 
+import readline
 import yaml
 from profanityfilter import ProfanityFilter
 from func_timeout import func_timeout, FunctionTimedOut


### PR DESCRIPTION
Without this it seems that at least the arrow keys and home and end keys produce escape sequences when pressed in Linux during prompts, instead of moving the cursor around.