### PR TITLE
/retry for a new story start

### DIFF
--- a/play.py
+++ b/play.py
@@ -564,29 +564,29 @@ def play_aidungeon_2():
                         console_print("You make sure to remember {}.".format(" ".join(action.split(" ")[1:])))
 
                 elif command == 'retry':
-
-                    if len(story_manager.story.actions) is 0:
-                        console_print("There is nothing to retry.")
-                        continue
-
-                    last_action = story_manager.story.actions.pop()
-                    last_result = story_manager.story.results.pop()
-
-                    try:
+                    if len(story_manager.story.actions) > 0:
+                        last_action = story_manager.story.actions.pop()
+                        last_result = story_manager.story.results.pop()
                         try:
                             story_manager.act_with_timeout(last_action)
                             console_print(last_action)
                             console_print(story_manager.story.results[-1])
                         except FunctionTimedOut:
                             console_print("That input caused the model to hang (timeout is {}, use infto ## command to change)".format(story_manager.inference_timeout))
+                        except NameError:
+                            pass
+                        finally:
                             if ping:
                                 playsound('ping.mp3')
-                    except NameError:
-                        pass
-                    if ping:
-                        playsound('ping.mp3')
-
-                    continue
+                    else:
+                        # Retry for another story start
+                        block = story_manager.generator.generate(story_manager.story.context + story_manager.story.story_prompt)
+                        block = cut_trailing_sentence(block)
+                        story_manager.start_new_story(
+                            story_prompt=story_manager.story.story_prompt, context=context, upload_story=upload_story
+                        )
+                        print("\n")
+                        console_print(str(story_manager.story))
 
                 elif command == 'context':
                     try:
@@ -605,17 +605,15 @@ def play_aidungeon_2():
                 elif command == 'alter':
                     try:
                         console_print("\nThe AI thinks this was what happened:\n")
-                        try:
-                            current_result = story_manager.story.results[-1]
-                        except IndexError:
-                            current_result = story_manager.story.story_start
+                        current_result = (
+                            story_manager.story.results[-1] if len(story_manager.story.results) > 0
+                            else story_manager.story.story_start
+                        )
                         new_result = string_edit(current_result)
-                        if new_result is None:
-                            pass
-                        else:
-                            try:
+                        if new_result is not None:
+                            if len(story_manager.story.results) > 0:
                                 story_manager.story.results[-1] = new_result
-                            except IndexError:
+                            else:
                                 story_manager.story.story_start = new_result
                             console_print("Result updated.\n")
                     except:

--- a/story/story_manager.py
+++ b/story/story_manager.py
@@ -17,9 +17,10 @@ save_path = "./saves/"
 
 class Story:
     def __init__(
-        self, story_start, context="", seed=None, game_state=None
+        self, story_start, story_prompt="", context="", seed=None, game_state=None
     ):
         self.story_start = story_start
+        self.story_prompt = story_prompt
         self.context = context
         self.rating = -1
 
@@ -51,6 +52,10 @@ class Story:
         self.context = story_dict["context"]
         self.uuid = story_dict["uuid"]
 
+        if "story_prompt" in story_dict.keys():
+            self.story_prompt = story_dict["story_prompt"]
+        else:
+            self.story_prompt = ""
         if "rating" in story_dict.keys():
             self.rating = story_dict["rating"]
         else:
@@ -95,6 +100,7 @@ class Story:
         story_dict["choices"] = self.choices
         story_dict["possible_action_results"] = self.possible_action_results
         story_dict["game_state"] = self.game_state
+        story_dict["story_prompt"] = self.story_prompt
         story_dict["context"] = self.context
         story_dict["uuid"] = self.uuid
         story_dict["rating"] = self.rating
@@ -134,6 +140,7 @@ class StoryManager:
         block = cut_trailing_sentence(block)
         self.story = Story(
             context + story_prompt + block,
+            story_prompt=story_prompt,
             context=context,
             game_state=game_state
         )


### PR DESCRIPTION
When at the start of the story, /retry will start a new story with the current context + story_prompt.

To make this work, a new 'story_prompt' property is added to the Story class and stored with the save file, similar to 'context'. When loading older saves lacking 'story_prompt', it will be initialized as an empty string, so this change won't be entirely compatible with previous saves, but otherwise shouldn't affect anything else.